### PR TITLE
Fix empty shelf

### DIFF
--- a/lib/vsc/utils/cache.py
+++ b/lib/vsc/utils/cache.py
@@ -100,7 +100,7 @@ class FileCache(object):
                         self.log.raiseException("Could not load pickle data from %s" % (self.filename,))
             finally:
                 f.close()
-        except (OSError, IOError), err:
+        except (OSError, IOError, ValueError), err:
             self.log.warning("Could not access the file cache at %s [%s]" % (self.filename, err))
             self.shelf = {}
             self.log.info("Cache in %s starts with an empty shelf" % (self.filename,))

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-utils',
-    'version': '1.6.1',
+    'version': '1.6.2',
     'author': [ag, sdw],
     'maintainer': [ag, sdw],
     'packages': ['vsc', 'vsc.utils'],


### PR DESCRIPTION
When the cache file does not contain a valid JSON object but it can be decoded by jsonpickle, it throws a ValueError. This occurs for example if the file has size zero.