### PR TITLE
added vsc.utils as only namespace package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, sdw
 
 PACKAGE = {
-    'version': '1.8.3',
+    'version': '1.8.4',
     'author': [ag, sdw],
     'maintainer': [ag, sdw],
     'excluded_pkgs_rpm': ['vsc', 'vsc.utils'],  # vsc is default, vsc.utils is provided by vsc-base
-    'namespace_packages': ['vsc', 'vsc.utils'],
+    'namespace_packages': [],  # becuase of the above lines we're not in the vsc and  vsc.utils namespace
     'tests_require': ['mock'],
     'install_requires': [
         'vsc-base >= 2.4.16',


### PR DESCRIPTION
don't claim we're in the vsc namespace, we're not, only in the vsc.utils namespace

this is actually the real fix