### PR TITLE
Use valid default value for retrieve_timestamp_with_default

### DIFF
--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/__init__.py
+++ b/lib/vsc/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/availability.py
+++ b/lib/vsc/utils/availability.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/cache.py
+++ b/lib/vsc/utils/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/crypt.py
+++ b/lib/vsc/utils/crypt.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2018 Ghent University
+# Copyright 2009-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/fs_store.py
+++ b/lib/vsc/utils/fs_store.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/lock.py
+++ b/lib/vsc/utils/lock.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/nagios.py
+++ b/lib/vsc/utils/nagios.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/pickle_files.py
+++ b/lib/vsc/utils/pickle_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/rest_oauth.py
+++ b/lib/vsc/utils/rest_oauth.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/script_tools.py
+++ b/lib/vsc/utils/script_tools.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/timestamp.py
+++ b/lib/vsc/utils/timestamp.py
@@ -39,6 +39,7 @@ from vsc.utils.dateandtime import utc
 
 LDAP_DATETIME_TIMEFORMAT = "%Y%m%d%H%M%SZ"
 
+DEFAULT_TIMESTAMP = "20140101000000Z"
 
 
 def convert_to_datetime(timestamp=None):
@@ -132,7 +133,7 @@ def write_timestamp(filename, timestamp):
     cache.close()
 
 
-def retrieve_timestamp_with_default(filename, start_timestamp=None, default_timestamp="201401010000", delta=-10):
+def retrieve_timestamp_with_default(filename, start_timestamp=None, default_timestamp=DEFAULT_TIMESTAMP, delta=-10):
     """
     Return a tuple consisting of the following values:
     - the timestamp from the given file if the start_timestamp is not provided

--- a/lib/vsc/utils/timestamp.py
+++ b/lib/vsc/utils/timestamp.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2018 Ghent University
+# Copyright 2009-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/timestamp.py
+++ b/lib/vsc/utils/timestamp.py
@@ -132,10 +132,10 @@ def write_timestamp(filename, timestamp):
     cache.close()
 
 
-def retrieve_timestamp_with_default(filename, start_timestamp=None, default_timestamp="2014010100000Z", delta=-10):
+def retrieve_timestamp_with_default(filename, start_timestamp=None, default_timestamp="201401010000", delta=-10):
     """
     Return a tuple consisting of the following values:
-    - the timestamp from the given file if the start_timestamp is not provided 
+    - the timestamp from the given file if the start_timestamp is not provided
       and fall back on default_timestamp if needed.
     - the current time based on the given delta (offset compared to now(tz=utc) in seconds), defaulting to -10s.
     """

--- a/lib/vsc/utils/timestamp_pid_lockfile.py
+++ b/lib/vsc/utils/timestamp_pid_lockfile.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, sdw
 
 PACKAGE = {
-    'version': '1.10.0',
+    'version': '1.10.1',
     'author': [ag, sdw],
     'maintainer': [ag, sdw],
     'excluded_pkgs_rpm': ['vsc', 'vsc.utils'],  # vsc is default, vsc.utils is provided by vsc-base

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,4 +1,29 @@
 #
+# Copyright 2019-2019 Ghent University
+#
+# This file is part of vsc-utils,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-utils
+#
+# vsc-utils is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-utils is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-utils. If not, see <http://www.gnu.org/licenses/>.
+#
+#
 # Copyright 2016-2016 Ghent University
 #
 # This file is part of vsc-utils,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,29 @@
 #
+# Copyright 2019-2019 Ghent University
+#
+# This file is part of vsc-utils,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-utils
+#
+# vsc-utils is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-utils is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-utils. If not, see <http://www.gnu.org/licenses/>.
+#
+#
 # Copyright 2016-2016 Ghent University
 #
 # This file is part of vsc-utils,

--- a/test/cache.py
+++ b/test/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/nagios.py
+++ b/test/nagios.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/nagios_results.py
+++ b/test/nagios_results.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright 2012-2016 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/nagios_simple.py
+++ b/test/nagios_simple.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/script_tools.py
+++ b/test/script_tools.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/timestamp.py
+++ b/test/timestamp.py
@@ -132,6 +132,8 @@ class TestTimestamp(TestCase):
     @mock.patch('vsc.utils.timestamp.read_timestamp')
     def test_retrieve_timestamp(self, mock_read_timestamp):
         """Test for the filestamp retrieval."""
+        mock_read_timestamp.return_value = None
+        self.assertEqual(convert_to_unix_timestamp(DEFAULT_TIMESTAMP), retrieve_timestamp_with_default("f")[0])
 
         read_ts = "203412130101"
         mock_read_timestamp.return_value = read_ts
@@ -140,7 +142,6 @@ class TestTimestamp(TestCase):
         default_ts = "20150103"
         self.assertEqual(convert_to_unix_timestamp(start_ts), retrieve_timestamp_with_default("f", start_timestamp=start_ts)[0])
         self.assertEqual(convert_to_unix_timestamp(read_ts), retrieve_timestamp_with_default("f", default_timestamp=default_ts)[0])
-        self.assertEqual(convert_to_unix_timestamp(DEFAULT_TIMESTAMP), retrieve_timestamp_with_default("f")[0])
 
         self.assertEqual(utc, retrieve_timestamp_with_default("f", default_timestamp="20140102")[1].tzinfo)
 

--- a/test/timestamp.py
+++ b/test/timestamp.py
@@ -140,6 +140,7 @@ class TestTimestamp(TestCase):
         default_ts = "20150103"
         self.assertEqual(convert_to_unix_timestamp(start_ts), retrieve_timestamp_with_default("f", start_timestamp=start_ts)[0])
         self.assertEqual(convert_to_unix_timestamp(read_ts), retrieve_timestamp_with_default("f", default_timestamp=default_ts)[0])
+        self.assertEqual(convert_to_unix_timestamp("201401010000"), retrieve_timestamp_with_default("f")[0])
 
         self.assertEqual(utc, retrieve_timestamp_with_default("f", default_timestamp="20140102")[1].tzinfo)
 

--- a/test/timestamp.py
+++ b/test/timestamp.py
@@ -36,7 +36,7 @@ from vsc.install.testing import TestCase
 from vsc.utils.dateandtime import utc
 
 from vsc.utils.timestamp import convert_to_datetime, convert_to_unix_timestamp, convert_timestamp
-from vsc.utils.timestamp import retrieve_timestamp_with_default
+from vsc.utils.timestamp import retrieve_timestamp_with_default, DEFAULT_TIMESTAMP
 
 
 class TestTimestamp(TestCase):
@@ -140,7 +140,7 @@ class TestTimestamp(TestCase):
         default_ts = "20150103"
         self.assertEqual(convert_to_unix_timestamp(start_ts), retrieve_timestamp_with_default("f", start_timestamp=start_ts)[0])
         self.assertEqual(convert_to_unix_timestamp(read_ts), retrieve_timestamp_with_default("f", default_timestamp=default_ts)[0])
-        self.assertEqual(convert_to_unix_timestamp("201401010000"), retrieve_timestamp_with_default("f")[0])
+        self.assertEqual(convert_to_unix_timestamp(DEFAULT_TIMESTAMP), retrieve_timestamp_with_default("f")[0])
 
         self.assertEqual(utc, retrieve_timestamp_with_default("f", default_timestamp="20140102")[1].tzinfo)
 

--- a/test/timestamp.py
+++ b/test/timestamp.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2018 Ghent University
+# Copyright 2018-2019 Ghent University
 #
 # This file is part of vsc-utils,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
Without this you get:

```
>>> retrieve_timestamp_with_default('/tmp/bla.txt')
Exception: invalid format provided 2014010100000Z
```