### PR TITLE
Removed Content-Type header from request_access_token

### DIFF
--- a/lib/vsc/utils/rest_oauth.py
+++ b/lib/vsc/utils/rest_oauth.py
@@ -40,7 +40,6 @@ def request_access_token(opener, path, client_id, client_secret):
                                 "client_id": client_id,
                                 "client_secret": client_secret})
     request = urllib2.Request(path, payload)
-    request.add_header('Content-Type', 'application/json')
     request.get_method = lambda: 'POST'
     uri = opener.open(request)
     response = uri.read()


### PR DESCRIPTION
Removed Content-Type header from request_access_token because it resulted in a HTTPError of 400 (Bad request).