### PR TITLE
don't drop the original message on parsing stats

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: install tox

--- a/lib/vsc/utils/nagios.py
+++ b/lib/vsc/utils/nagios.py
@@ -523,8 +523,8 @@ class SimpleNagios(NagiosResult):
                 if "warning" in v and NagiosRange(v['warning']).alert(v['value']):
                     warn = True
                     msg.append(k)
-
-        msg.append(self.message)
+        if self.message:
+            msg.append(self.message)
         return warn, crit, ', '.join(msg)
 
     def _eval_and_exit(self, **kwargs):

--- a/lib/vsc/utils/nagios.py
+++ b/lib/vsc/utils/nagios.py
@@ -524,6 +524,7 @@ class SimpleNagios(NagiosResult):
                     warn = True
                     msg.append(k)
 
+        msg.append(self.message)
         return warn, crit, ', '.join(msg)
 
     def _eval_and_exit(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
 ]
 
 PACKAGE = {
-    'version': '2.2.7',
+    'version': '2.2.8',
     'author': [ag, sdw],
     'maintainer': [ag, sdw],
     'excluded_pkgs_rpm': ['vsc', 'vsc.utils'],  # vsc is default, vsc.utils is provided by vsc-base

--- a/test/nagios_simple.py
+++ b/test/nagios_simple.py
@@ -129,22 +129,22 @@ class TestSimpleNagios(TestCase):
         kwargs.update(kwargsmore)
 
         # critical value in message
-        self._basic_test_single_instance(kwargs, 'CRITICAL value1 | value0=3;5;10; value1=15;5;10; value2=7;5;10;',
+        self._basic_test_single_instance(kwargs, 'CRITICAL value1, hello | value0=3;5;10; value1=15;5;10; value2=7;5;10;',
                                          NAGIOS_EXIT_CRITICAL)
 
         # all warning values in message
         kwargs['value1'] = 7
         self._basic_test_single_instance(
-            kwargs, 'WARNING value1, value2 | value0=3;5;10; value1=7;5;10; value2=7;5;10;', NAGIOS_EXIT_WARNING)
+            kwargs, 'WARNING value1, value2, hello | value0=3;5;10; value1=7;5;10; value2=7;5;10;', NAGIOS_EXIT_WARNING)
 
         # warning in message
         kwargs['value1'] = 5
-        self._basic_test_single_instance(kwargs, 'WARNING value2 | value0=3;5;10; value1=5;5;10; value2=7;5;10;',
+        self._basic_test_single_instance(kwargs, 'WARNING value2, hello | value0=3;5;10; value1=5;5;10; value2=7;5;10;',
                                          NAGIOS_EXIT_WARNING)
 
         # no warning/critical; so regular message
         kwargs['value2'] = 5
-        self._basic_test_single_instance(kwargs, 'OK hello | value0=3;5;10; value1=5;5;10; value2=5;5;10;',
+        self._basic_test_single_instance(kwargs, 'OK hello, hello | value0=3;5;10; value1=5;5;10; value2=5;5;10;',
                                          NAGIOS_EXIT_OK)
 
 

--- a/test/nagios_simple.py
+++ b/test/nagios_simple.py
@@ -144,7 +144,7 @@ class TestSimpleNagios(TestCase):
 
         # no warning/critical; so regular message
         kwargs['value2'] = 5
-        self._basic_test_single_instance(kwargs, 'OK hello, hello | value0=3;5;10; value1=5;5;10; value2=5;5;10;',
+        self._basic_test_single_instance(kwargs, 'OK hello | value0=3;5;10; value1=5;5;10; value2=5;5;10;',
                                          NAGIOS_EXIT_OK)
 
 

--- a/test/nagios_simple.py
+++ b/test/nagios_simple.py
@@ -109,13 +109,13 @@ class TestSimpleNagios(TestCase):
         self._basic_test_single_instance(kwargs, 'OK hello | value1=5;5;10;', NAGIOS_EXIT_OK)
         # goutside warning range, perfdata with warning in message
         kwargs['value1'] = 7
-        self._basic_test_single_instance(kwargs, 'WARNING value1 | value1=7;5;10;', NAGIOS_EXIT_WARNING)
+        self._basic_test_single_instance(kwargs, 'WARNING value1, hello | value1=7;5;10;', NAGIOS_EXIT_WARNING)
         # outside critical range?
         kwargs['value1'] = 10
-        self._basic_test_single_instance(kwargs, 'WARNING value1 | value1=10;5;10;', NAGIOS_EXIT_WARNING)
+        self._basic_test_single_instance(kwargs, 'WARNING value1, hello | value1=10;5;10;', NAGIOS_EXIT_WARNING)
         # greater
         kwargs['value1'] = 15
-        self._basic_test_single_instance(kwargs, 'CRITICAL value1 | value1=15;5;10;', NAGIOS_EXIT_CRITICAL)
+        self._basic_test_single_instance(kwargs, 'CRITICAL value1, hello | value1=15;5;10;', NAGIOS_EXIT_CRITICAL)
 
         # mixed
         kwargsmore = {


### PR DESCRIPTION
the current setup drops the nagios message if there was one, and replaces it by the statistic name. so it might be

```
msg = "failed in service nrpe" 
stats= {'fail': 1}
```
and it will return just `fail` as a message.
The only place where I see this function being used correctly is in service_sanity. other uses just dance around it and do checking themselves. (which is wrong, but another discussion)

In fact, it does this for OK values, but not for failed values, which is counterintuitive.